### PR TITLE
Add support for u/i128 types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,12 +270,14 @@ impl Abomonation for u8 { }
 impl Abomonation for u16 { }
 impl Abomonation for u32 { }
 impl Abomonation for u64 { }
+impl Abomonation for u128 { }
 impl Abomonation for usize { }
 
 impl Abomonation for i8 { }
 impl Abomonation for i16 { }
 impl Abomonation for i32 { }
 impl Abomonation for i64 { }
+impl Abomonation for i128 { }
 impl Abomonation for isize { }
 
 impl Abomonation for f32 { }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -12,10 +12,12 @@ use abomonation::*;
 #[test] fn test_option_vec() { _test_pass(vec![Some(vec![0, 1, 2])]); }
 #[test] fn test_u32x4_pass() { _test_pass(vec![((1,2,3),vec![(0u32, 0u32, 0u32, 0u32); 1024])]); }
 #[test] fn test_u64_pass() { _test_pass(vec![0u64; 1024]); }
+#[test] fn test_u128_pass() { _test_pass(vec![0u128; 1024]); }
 #[test] fn test_string_pass() { _test_pass(vec![format!("grawwwwrr!"); 1024]); }
 #[test] fn test_vec_u_s_pass() { _test_pass(vec![vec![(0u64, format!("grawwwwrr!")); 32]; 32]); }
 
 #[test] fn test_u64_fail() { _test_fail(vec![0u64; 1024]); }
+#[test] fn test_u128_fail() { _test_fail(vec![0u128; 1024]); }
 #[test] fn test_string_fail() { _test_fail(vec![format!("grawwwwrr!"); 1024]); }
 #[test] fn test_vec_u_s_fail() { _test_fail(vec![vec![(0u64, format!("grawwwwrr!")); 32]; 32]); }
 
@@ -26,6 +28,7 @@ use abomonation::*;
 #[test] fn test_option_vec_size() { _test_size(vec![Some(vec![0, 1, 2])]); }
 #[test] fn test_u32x4_size() { _test_size(vec![((1,2,3),vec![(0u32, 0u32, 0u32, 0u32); 1024])]); }
 #[test] fn test_u64_size() { _test_size(vec![0u64; 1024]); }
+#[test] fn test_u128_size() { _test_size(vec![0u128; 1024]); }
 #[test] fn test_string_size() { _test_size(vec![format!("grawwwwrr!"); 1024]); }
 #[test] fn test_vec_u_s_size() { _test_size(vec![vec![(0u64, format!("grawwwwrr!")); 32]; 32]); }
 


### PR DESCRIPTION
Rust supports `i128` and `u128` since version 1.26.0. I think it's time to add support to Abomination as well.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>