### PR TITLE
Add support for ::std::net types like sockets and IP addresses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,3 +505,16 @@ impl<T: Abomonation> Abomonation for Box<T> {
 #[inline] unsafe fn typed_to_bytes<T>(slice: &[T]) -> &[u8] {
     std::slice::from_raw_parts(slice.as_ptr() as *const u8, slice.len() * mem::size_of::<T>())
 }
+
+mod network {
+    use Abomonation;
+    use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6, IpAddr, Ipv4Addr, Ipv6Addr};
+
+    impl Abomonation for IpAddr { }
+    impl Abomonation for Ipv4Addr { }
+    impl Abomonation for Ipv6Addr { }
+
+    impl Abomonation for SocketAddr { }
+    impl Abomonation for SocketAddrV4 { }
+    impl Abomonation for SocketAddrV6 { }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -133,3 +133,20 @@ fn test_multiple_encode_decode() {
     let (t, r) = unsafe { decode::<Vec<i32>>(r) }.unwrap(); assert!(*t == vec![1,2,3]);
     let (t, _r) = unsafe { decode::<String>(r) }.unwrap(); assert!(*t == "grawwwwrr".to_owned());
 }
+
+#[test]
+fn test_net_types() {
+
+    use std::net::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr};
+
+    let socket_addr4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(128, 0, 0, 1)), 1234);
+    let socket_addr6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1234);
+
+    let mut bytes = Vec::new();
+
+    unsafe { encode(&socket_addr4, &mut bytes).unwrap(); }
+    unsafe { encode(&socket_addr6, &mut bytes).unwrap(); }
+
+    let (t, r) = unsafe { decode::<SocketAddr>(&mut bytes) }.unwrap(); assert!(*t == socket_addr4);
+    let (t, _r) = unsafe { decode::<SocketAddr>(r) }.unwrap(); assert!(*t == socket_addr6);
+}


### PR DESCRIPTION
Add support for types encoding IPv4/6 addresses and their corresponding sockets.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>