### PR TITLE
Fix link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Abomonation (spelling intentional) is a serialization library for Rust based on 
 
 **Warning**: Abomonation should not be used on any data you care strongly about, or from any computer you value the data on. The `encode` and `decode` methods do things that may be undefined behavior, and you shouldn't stand for that. Specifically, `encode` exposes padding bytes to `memcpy`, and `decode` doesn't much respect alignment.
 
-Please consult the [abomonation documentation](https://frankmcsherry.github.com/abomonation) for more specific information.
+Please consult the [abomonation documentation](https://timelydataflow.github.io/abomonation/abomonation/index.html) for more specific information.
 
 Here is an example of using Abomonation. It is very easy to use. Frighteningly easy.
 


### PR DESCRIPTION
The old link resolved to a 404 page :)