### PR TITLE
No std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ license = "MIT"
 
 [dependencies]
 genio = { version = "0.2.1", optional = true }
+smoltcp = { version = "0.7.1", default-features = false, features = [ "alloc", "log", "proto-ipv4", "proto-ipv6", "proto-igmp", "proto-dhcpv4", "socket-raw", "socket-icmp", "socket-udp", "socket-tcp" ], optional = true }
 
 [dev-dependencies]
 recycler="0.1.4"
 
 [features]
-no_std = ["genio"]
+default = []
+no_std = ["genio", "smoltcp"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,11 @@ repository = "https://github.com/TimelyDataflow/abomonation.git"
 keywords = ["abomonation"]
 license = "MIT"
 
+[dependencies]
+genio = { version = "0.2.1", optional = true }
+
 [dev-dependencies]
 recycler="0.1.4"
+
+[features]
+no_std = ["genio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["abomonation"]
 license = "MIT"
 
 [dependencies]
-bare-io = { version = "0.2.1", default-features = false, features = [ "alloc" ] }
+core2 = { version = "0.3", default-features = false, features = [ "alloc" ] }
 smoltcp = { version = "0.7.1", default-features = false, features = [ "alloc", "log", "proto-ipv4", "proto-ipv6", "proto-igmp", "proto-dhcpv4", "socket-raw", "socket-icmp", "socket-udp", "socket-tcp" ] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["abomonation"]
 license = "MIT"
 
 [dependencies]
-genio = { version = "0.2.1", optional = true }
+bare-io = { version = "0.2.1", default-features = false, features = [ "alloc" ],  optional = true }
 smoltcp = { version = "0.7.1", default-features = false, features = [ "alloc", "log", "proto-ipv4", "proto-ipv6", "proto-igmp", "proto-dhcpv4", "socket-raw", "socket-icmp", "socket-udp", "socket-tcp" ], optional = true }
 
 [dev-dependencies]
@@ -21,4 +21,4 @@ recycler="0.1.4"
 
 [features]
 default = []
-no_std = ["genio", "smoltcp"]
+no_std = ["bare-io", "smoltcp"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["abomonation"]
 license = "MIT"
 
 [dependencies]
-bare-io = { version = "0.2.1", default-features = false, features = [ "alloc" ],  optional = true }
-smoltcp = { version = "0.7.1", default-features = false, features = [ "alloc", "log", "proto-ipv4", "proto-ipv6", "proto-igmp", "proto-dhcpv4", "socket-raw", "socket-icmp", "socket-udp", "socket-tcp" ], optional = true }
+bare-io = { version = "0.2.1", default-features = false, features = [ "alloc" ] }
+smoltcp = { version = "0.7.1", default-features = false, features = [ "alloc", "log", "proto-ipv4", "proto-ipv6", "proto-igmp", "proto-dhcpv4", "socket-raw", "socket-icmp", "socket-udp", "socket-tcp" ] }
 
 [dev-dependencies]
 recycler="0.1.4"
 
 [features]
-default = []
-no_std = ["bare-io", "smoltcp"]
+default = ["std"]
+std = []

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -4,7 +4,7 @@ extern crate abomonation;
 extern crate test;
 
 #[cfg(not(feature="std"))]
-extern crate bare_io;
+extern crate core2;
 
 use test::Bencher;
 use abomonation::{Abomonation, encode, decode};
@@ -17,8 +17,8 @@ use {
 
 #[cfg(not(feature="std"))]
 use {
-	bare_io::Write,
-	bare_io::Result as IOResult,
+	core2::io::Write,
+	core2::io::Result as IOResult,
 };
 
 #[bench]

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -3,8 +3,23 @@
 extern crate abomonation;
 extern crate test;
 
+#[cfg(feature="no_std")]
+extern crate bare_io;
+
 use test::Bencher;
 use abomonation::{Abomonation, encode, decode};
+
+#[cfg(not(feature="no_std"))]
+use {
+	std::io::Write,
+	std::io::Result as IOResult,
+};
+
+#[cfg(feature="no_std")]
+use {
+	bare_io::Write,
+	bare_io::Result as IOResult,
+};
 
 #[bench]
 fn bench_populate(b: &mut Bencher) {

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -3,19 +3,19 @@
 extern crate abomonation;
 extern crate test;
 
-#[cfg(feature="no_std")]
+#[cfg(not(feature="std"))]
 extern crate bare_io;
 
 use test::Bencher;
 use abomonation::{Abomonation, encode, decode};
 
-#[cfg(not(feature="no_std"))]
+#[cfg(feature="std")]
 use {
 	std::io::Write,
 	std::io::Result as IOResult,
 };
 
-#[cfg(feature="no_std")]
+#[cfg(not(feature="std"))]
 use {
 	bare_io::Write,
 	bare_io::Result as IOResult,

--- a/src/abomonated.rs
+++ b/src/abomonated.rs
@@ -1,7 +1,18 @@
+#![cfg_attr(feature = "no_std", no_std)]
 
-use std::mem::transmute;
-use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
+#[cfg(not(feature="no_std"))]
+use {
+    std::mem::transmute,
+    std::marker::PhantomData,
+    std::ops::{Deref, DerefMut},
+};
+
+#[cfg(feature="no_std")]
+use {
+    core::mem::transmute,
+    core::marker::PhantomData,
+    core::ops::{Deref, DerefMut},
+};
 
 use super::{Abomonation, decode};
 

--- a/src/abomonated.rs
+++ b/src/abomonated.rs
@@ -1,13 +1,13 @@
-#![cfg_attr(feature = "no_std", no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature="no_std"))]
+#[cfg(feature="std")]
 use {
     std::mem::transmute,
     std::marker::PhantomData,
     std::ops::{Deref, DerefMut},
 };
 
-#[cfg(feature="no_std")]
+#[cfg(not(feature="std"))]
 use {
     core::mem::transmute,
     core::marker::PhantomData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,6 @@ pub trait Abomonation {
 /// }
 /// ```
 #[macro_export]
-#[deprecated(since="0.5", note="please use the abomonation_derive crate")]
 macro_rules! unsafe_abomonate {
     ($t:ty) => {
         impl Abomonation for $t { }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 #![cfg_attr(not(feature="std"), no_std)]
 
 #[cfg(not(feature="std"))]
-extern crate bare_io;
+extern crate core2;
 
 #[cfg(not(feature="std"))]
 extern crate smoltcp;
@@ -68,8 +68,8 @@ use {
     core::ops::Range,
     core::ptr::write as ptr_write,
 
-    bare_io::Write,
-    bare_io::Result as IOResult,
+    core2::io::Write,
+    core2::io::Result as IOResult,
 
     alloc::vec::Vec,
     alloc::boxed::Box,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,19 +34,18 @@
 //!     assert!(remaining.len() == 0);
 //! }
 //! ```
+#![cfg_attr(not(feature="std"), no_std)]
 
-#![cfg_attr(feature = "no_std", no_std)]
-
-#[cfg(feature="no_std")]
+#[cfg(not(feature="std"))]
 extern crate bare_io;
 
-#[cfg(feature="no_std")]
+#[cfg(not(feature="std"))]
 extern crate smoltcp;
 
-#[cfg(feature="no_std")]
+#[cfg(not(feature="std"))]
 extern crate alloc;
 
-#[cfg(not(feature="no_std"))]
+#[cfg(feature="std")]
 use {
     std::mem as mem,       // yup, used pretty much everywhere.
     std::io::Write,        // for bytes.write_all; push_all is unstable and extend is slow.
@@ -59,7 +58,7 @@ use {
     std::ptr::write as ptr_write,
 };
 
-#[cfg(feature="no_std")]
+#[cfg(not(feature="std"))]
 use {
     core::mem as mem,
     core::marker::PhantomData,
@@ -578,22 +577,22 @@ impl<T: Abomonation> Abomonation for Box<T> {
 mod network {
     use Abomonation;
 
-    #[cfg(not(feature="no_std"))]
+    #[cfg(feature="std")]
     use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6, IpAddr, Ipv4Addr, Ipv6Addr};
 
-    #[cfg(feature="no_std")]
+    #[cfg(not(feature="std"))]
     use smoltcp::wire::{IpAddress as IpAddr, Ipv4Address as Ipv4Addr, Ipv6Address as Ipv6Addr};
 
     impl Abomonation for IpAddr { }
     impl Abomonation for Ipv4Addr { }
     impl Abomonation for Ipv6Addr { }
 
-    #[cfg(not(feature="no_std"))]
+    #[cfg(feature="std")]
     impl Abomonation for SocketAddr { }
 
-    #[cfg(not(feature="no_std"))]
+    #[cfg(feature="std")]
     impl Abomonation for SocketAddrV4 { }
 
-    #[cfg(not(feature="no_std"))]
+    #[cfg(feature="std")]
     impl Abomonation for SocketAddrV6 { }
 }


### PR DESCRIPTION
Hello! I've created a no-std version of abomonation by using ```core2::io::Write``` and ```core2::io::Result``` from the [core2 crate](https://github.com/technocreatives/core2).

I am fairly new to rust and I am happy to rework my changes if there are any stylistic or other issues with the current implementation. I have not looked into creating a no-std version of the abomonation_derive crate at this time. Because of this, I removed the deprecation warning from ```unsafe_abomonate``` since I wasn't sure if I could make the deprecation warning feature dependent (e.g., warn for std, do not warn for no-std). I welcome suggestions for how to handle this more gracefully.