### PR TITLE
Implement Abomonation for PathBuf

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,6 @@
 extern crate abomonation;
 
+use std::path::PathBuf;
 use abomonation::*;
 
 #[test] fn test_array() { _test_pass(vec![[0, 1, 2]; 1024]); }
@@ -13,11 +14,13 @@ use abomonation::*;
 #[test] fn test_u64_pass() { _test_pass(vec![0u64; 1024]); }
 #[test] fn test_u128_pass() { _test_pass(vec![0u128; 1024]); }
 #[test] fn test_string_pass() { _test_pass(vec![format!("grawwwwrr!"); 1024]); }
+#[test] fn test_pathbuf_pass() { _test_pass(vec![PathBuf::from(format!("grawwwwrr!")); 1024]); }
 #[test] fn test_vec_u_s_pass() { _test_pass(vec![vec![(0u64, format!("grawwwwrr!")); 32]; 32]); }
 
 #[test] fn test_u64_fail() { _test_fail(vec![0u64; 1024]); }
 #[test] fn test_u128_fail() { _test_fail(vec![0u128; 1024]); }
 #[test] fn test_string_fail() { _test_fail(vec![format!("grawwwwrr!"); 1024]); }
+#[test] fn test_pathbuf_fail() { _test_fail(vec![PathBuf::from(format!("grawwwwrr!")); 1024]); }
 #[test] fn test_vec_u_s_fail() { _test_fail(vec![vec![(0u64, format!("grawwwwrr!")); 32]; 32]); }
 
 #[test] fn test_array_size() { _test_size(vec![[0, 1, 2]; 1024]); }
@@ -29,6 +32,7 @@ use abomonation::*;
 #[test] fn test_u64_size() { _test_size(vec![0u64; 1024]); }
 #[test] fn test_u128_size() { _test_size(vec![0u128; 1024]); }
 #[test] fn test_string_size() { _test_size(vec![format!("grawwwwrr!"); 1024]); }
+#[test] fn test_pathbuf_size() { _test_size(vec![PathBuf::from(format!("grawwwwrr!")); 1024]); }
 #[test] fn test_vec_u_s_size() { _test_size(vec![vec![(0u64, format!("grawwwwrr!")); 32]; 32]); }
 
 #[test]


### PR DESCRIPTION
This is a flawed implementation of the `Abomonation` trait for the `PathBuf` type from the standard library. I'd love some feedback on whether you'd be open to merge an improved implementation (some thoughts below).

The motivation for this: I'm trying out differential-dataflow (amazing library!) for a code analysis tool and have a bunch of filesystem paths that I'd like to send through a dataflow graph.

The flaw in the implementation in this PR (that I'm aware of, there might be others): it uses a unix-specific function and so will cause compilation failures on non-unix platforms. Some options I see:
- Use a macro to only add the instance on Unix platforms
- Use [`OsStr::to_str`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html#method.to_str) to get a `&str`, then call `as_bytes()` on that. This path should work on all platforms, but has two downsides I'm aware of:
  - `OsStr::to_str` fails when the path contains non-unicode characters, so we'd have that new error case.
  - `OsStr::to_str` performs a unicode check, so it's not as fast.

Would this PR be acceptable with one of the changes above? I can also imagine there's entirely different problems that I'm not aware of!