### PR TITLE
Use casts instead of transmute

### DIFF
--- a/src/abomonated.rs
+++ b/src/abomonated.rs
@@ -1,5 +1,4 @@
 
-use std::mem::transmute;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
@@ -8,7 +7,7 @@ use super::{Abomonation, decode};
 /// A type wrapping owned decoded abomonated data.
 ///
 /// This type ensures that decoding and pointer correction has already happened,
-/// and implements `Deref<Target=T>` using a pointer cast (transmute).
+/// and implements `Deref<Target=T>` using a pointer cast.
 ///
 /// #Safety
 ///
@@ -121,7 +120,6 @@ impl<T, S: DerefMut<Target=[u8]>> Deref for Abomonated<T, S> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
-        let result: &T = unsafe { transmute(self.decoded.get_unchecked(0)) };
-        result
+        unsafe { &*(self.decoded.as_ptr() as *const T) }
     }
 }


### PR DESCRIPTION
This commit also replaces `.get_unchecked(0)` with `.as_ptr()` (when casting slice to typed object), which makes MIRI slightly happier (in previous approach, the pointer was valid only for the first byte) – in fact, it now passes tests with following flags:

    env MIRIFLAGS='-Zmiri-disable-alignment-check -Zmiri-disable-validation -Zmiri-tag-raw-pointers' \
        cargo miri test